### PR TITLE
fixed unbind all window resize event bug

### DIFF
--- a/messi.js
+++ b/messi.js
@@ -197,7 +197,7 @@ Messi.prototype = {
   
   unload: function() {
     if (this.visible) this.hide();
-    jQuery(window).unbind('resize', this.resize());
+    jQuery(window).unbind('resize', function () { this.resize(); }());
     this.messi.remove();
   },
 


### PR DESCRIPTION
when close messi popup window, all window resize events were unbinded.
I fixed it.
