### PR TITLE
Add check if options is defined

### DIFF
--- a/messi.js
+++ b/messi.js
@@ -208,7 +208,7 @@ jQuery.extend(Messi, {
 
   alert: function(data, callback, options) {        
       
-      var btntxt = (options.btnText) ? options.btnText : 'OK';
+      var btntxt = (options && options.btnText) ? options.btnText : 'OK';
       var buttons = [{id: 'ok', label: btntxt}];
       
       options = jQuery.extend({closeButton: false, modal: true, buttons: buttons, callback:function() {}}, options || {}, {show: true, unload: true, callback: callback});


### PR DESCRIPTION
There was no options, so options.btnText raises error. Add checking if options is defined.
I only use alert, but suppose in the rest functions should do the same.
