### PR TITLE
Update messi.js

### DIFF
--- a/messi.js
+++ b/messi.js
@@ -10,6 +10,7 @@
  */
 
 // Clase principal
+(function($) {
 function Messi(data, options) {
   
   var _this = this;
@@ -276,3 +277,6 @@ jQuery.extend(Messi, {
   }
   
 });
+
+$.Messi = Messi;
+})(jQuery);


### PR DESCRIPTION
The plugin Messi has a bad integration with JQuery, this makes it obligatory to "< script src="messi.js"> </script>" at the end of body, to fix this, change this:

(function($) {
    function Messi(e,t){
        ...
    }
    ...
    // End of file
    $.Messi = Messi;
})(jQuery);

This solves the problem (you can put the script anywhere in the code) and creates a healthier integration with JQuery, Example of the new call:

new $. Messi (message, options);
