### PR TITLE
add click to close feature

### DIFF
--- a/messi.js
+++ b/messi.js
@@ -95,6 +95,11 @@ function Messi(data, options) {
   
   // controlamos el redimensionamiento de la pantalla
   jQuery(window).bind('resize', function(){ _this.resize(); });
+
+  // close message if click anywhere on screen
+  if(_this.options.clickclose != null) {
+    jQuery(window).bind('mousedown touchstart', function() { _this.hide();});
+  }
   
   // configuramos el cierre automático
   if(_this.options.autoclose != null) {
@@ -125,7 +130,8 @@ Messi.prototype = {
     unload: true,                            // unload message after hide
     viewport: {top: '0px', left: '0px'},     // if not center message, sets X and Y position
     width: '500px',                          // message width
-    zIndex: 99999                            // message z-index
+    zIndex: 99999,                           // message z-index
+    clickclose: null                         // close message if click anywhere on screen
   },
   template: '<div class="messi"><div class="messi-box"><div class="messi-wrapper"><div class="messi-titlebox"><span class="messi-title"></span></div><div class="messi-content"></div><div class="messi-footbox"><div class="messi-actions"></div></div></div></div></div>',
   content: '<div></div>',


### PR DESCRIPTION
Hi, I love your plugin and added a feature for myself and I think you might be like to have it.
I have added an option : clickclose. If it is set to true, you can close message by click mouse anywhere on the screen.
I have not created min.js because I think you might have your own way to do it.
Merge if you like. Thank you, and your plugin!
